### PR TITLE
add ESMTP AUTH for LOGIN and PLAIN

### DIFF
--- a/example.php
+++ b/example.php
@@ -32,7 +32,15 @@ $sendEvent = new Event(Event::TRIGGER_MAIL_NEW, null, function($event, $from, $r
 		throw new Exception($mailer->ErrorInfo);
 	}
 });
+
+$authEvent = new Event(Event::TRIGGER_AUTH_ATTEMPT, null, function ($event, $type, $credentials) {
+    // Do stuff: Check credentials against database, ...
+
+    return true;
+});
+
 $server->eventAdd($sendEvent);
+$server->eventAdd($authEvent);
 
 // `loop()` is only a loop with `run()` executed.
 // So you need to execute `run()` in your own project to keep the SMTP server updated.

--- a/src/TheFox/Smtp/Client.php
+++ b/src/TheFox/Smtp/Client.php
@@ -282,7 +282,7 @@ class Client{
 		elseif($commandcmp == 'auth'){
 			$this->setStatus('hasAuth', true);
 			
-			if (empty($args)){
+			if(empty($args)){
 				return $this->sendSyntaxErrorInParameters();
 			}
 			

--- a/src/TheFox/Smtp/Client.php
+++ b/src/TheFox/Smtp/Client.php
@@ -323,7 +323,7 @@ class Client{
 			if($this->getStatus('hasAuth')){
 				if($this->getStatus('hasAuthPlain')){
 					$this->setStatus('hasAuthPlainUser', true);
-					$this->setCredentials([$command]);
+					$this->setCredentials(array($command));
 
 					if($this->authenticate('plain')){
 						return $this->sendAuthSuccessResponse();

--- a/src/TheFox/Smtp/Client.php
+++ b/src/TheFox/Smtp/Client.php
@@ -202,11 +202,12 @@ class Client{
 			#$this->log('debug', 'client '.$this->id.' helo');
 			$this->setStatus('hasHello', true);
 			$msg = '250-'.$this->getHostname().static::MSG_SEPARATOR;
-
-			for($i = 0; $i < count($this->extended_commands); $i++){
+			$count = count($this->extended_commands) - 1;
+			
+			for($i = 0; $i < $count; $i++){
 				$msg .= '250-'.$this->extended_commands[$i].static::MSG_SEPARATOR;
 			}
-
+			
 			$msg .= '250 '.end($this->extended_commands);
 
 			return $this->dataSend($msg);
@@ -285,7 +286,7 @@ class Client{
 			if($authentication == 'plain'){
 				$this->setStatus('hasAuthPlain', true);
 
-				if(isset($args[1])) {
+				if(isset($args[1])){
 					$this->setStatus('hasAuthPlainUser', true);
 					$this->setCredentials([$args[1]]);
 
@@ -320,7 +321,7 @@ class Client{
 				elseif($this->getStatus('hasAuthLogin')){
 					$credentials = $this->getCredentials();
 
-					if ($this->getStatus('hasAuthLoginUser')) {
+					if($this->getStatus('hasAuthLoginUser')){
 						$credentials['password'] = $command;
 						$this->setCredentials($credentials);
 
@@ -383,7 +384,7 @@ class Client{
 		$this->setStatus('hasAuth'.ucfirst($type), false);
 		$this->setStatus('hasAuth'.ucfirst($type).'User', false);
 		
-		if (!$attempt){
+		if(!$attempt){
 			return $this->sendAuthInvalid();
 		}
 		

--- a/src/TheFox/Smtp/Client.php
+++ b/src/TheFox/Smtp/Client.php
@@ -29,7 +29,7 @@ class Client{
 	private $mail = '';
 	private $hostname = '';
 	private $credentials = array();
-	private $extended_commands = array('AUTH PLAIN LOGIN', 'HELP');
+	private $extendedCommands = array('AUTH PLAIN LOGIN', 'HELP');
 	
 	public function __construct($hostname = 'localhost.localdomain'){
 		#print __CLASS__.'->'.__FUNCTION__.''."\n";
@@ -105,9 +105,9 @@ class Client{
 	
 	public function setIpPort($ip = '', $port = 0){
 		// @codeCoverageIgnoreStart
-		// if(!TEST){
-		// 	$this->getSocket()->getPeerName($ip, $port);
-		// }
+		if(!TEST){
+			$this->getSocket()->getPeerName($ip, $port);
+		}
 		// @codeCoverageIgnoreEnd
 		
 		$this->setIp($ip);
@@ -202,13 +202,13 @@ class Client{
 			#$this->log('debug', 'client '.$this->id.' helo');
 			$this->setStatus('hasHello', true);
 			$msg = '250-'.$this->getHostname().static::MSG_SEPARATOR;
-			$count = count($this->extended_commands) - 1;
+			$count = count($this->extendedCommands) - 1;
 			
 			for($i = 0; $i < $count; $i++){
-				$msg .= '250-'.$this->extended_commands[$i].static::MSG_SEPARATOR;
+				$msg .= '250-'.$this->extendedCommands[$i].static::MSG_SEPARATOR;
 			}
 			
-			$msg .= '250 '.end($this->extended_commands);
+			$msg .= '250 '.end($this->extendedCommands);
 
 			return $this->dataSend($msg);
 		}

--- a/src/TheFox/Smtp/Client.php
+++ b/src/TheFox/Smtp/Client.php
@@ -105,9 +105,9 @@ class Client{
 	
 	public function setIpPort($ip = '', $port = 0){
 		// @codeCoverageIgnoreStart
-		if(!TEST){
-			$this->getSocket()->getPeerName($ip, $port);
-		}
+		// if(!TEST){
+		// 	$this->getSocket()->getPeerName($ip, $port);
+		// }
 		// @codeCoverageIgnoreEnd
 		
 		$this->setIp($ip);
@@ -295,7 +295,11 @@ class Client{
 					$this->setStatus('hasAuthPlainUser', true);
 					$this->setCredentials(array($args[1]));
 
-					return $this->authenticate('plain');
+					if($this->authenticate('plain')){
+						return $this->sendAuthSuccessResponse();
+					}
+					
+					return $this->sendAuthInvalid();
 				}
 
 				return $this->sendAuthPlainResponse();
@@ -309,7 +313,7 @@ class Client{
 				return $this->sendCommandNotImplemented();
 			}
 			else{
-				return $this->sendSyntaxErrorCommandUnrecognized();
+				return $this->sendSyntaxErrorInParameters();
 			}
 		}
 		elseif($commandcmp == 'help'){
@@ -321,7 +325,11 @@ class Client{
 					$this->setStatus('hasAuthPlainUser', true);
 					$this->setCredentials([$command]);
 
-					return $this->authenticate('plain');
+					if($this->authenticate('plain')){
+						return $this->sendAuthSuccessResponse();
+					}
+					
+					return $this->sendAuthInvalid();
 				}
 				elseif($this->getStatus('hasAuthLogin')){
 					$credentials = $this->getCredentials();
@@ -330,7 +338,11 @@ class Client{
 						$credentials['password'] = $command;
 						$this->setCredentials($credentials);
 
-						return $this->authenticate('login');
+						if($this->authenticate('login')){
+							return $this->sendAuthSuccessResponse();
+						}
+						
+						return $this->sendAuthInvalid();
 					}
 
 					$this->setStatus('hasAuthLoginUser', true);
@@ -385,18 +397,18 @@ class Client{
 	/**
 	 * @codeCoverageIgnore
 	 */
-	public function authenticate($type){
-		$attempt = $this->getServer()->authenticateUser($type, $this->getCredentials());
+	public function authenticate($method){
+		$attempt = $this->getServer()->authenticateUser($method, $this->getCredentials());
 		
 		$this->setStatus('hasAuth', false);
-		$this->setStatus('hasAuth'.ucfirst($type), false);
-		$this->setStatus('hasAuth'.ucfirst($type).'User', false);
+		$this->setStatus('hasAuth'.ucfirst($method), false);
+		$this->setStatus('hasAuth'.ucfirst($method).'User', false);
 		
 		if(!$attempt){
-			return $this->sendAuthInvalid();
+			return false;
 		}
 		
-		return $this->sendAuthSuccessResponse();
+		return true;
 	}
 	
 	/**

--- a/src/TheFox/Smtp/Client.php
+++ b/src/TheFox/Smtp/Client.php
@@ -31,7 +31,7 @@ class Client{
 	private $credentials = array();
 	private $extended_commands = array('AUTH PLAIN LOGIN', 'HELP');
 	
-	public function __construct($hostname){
+	public function __construct($hostname = 'localhost.localdomain'){
 		#print __CLASS__.'->'.__FUNCTION__.''."\n";
 		
 		$this->hostname = $hostname;
@@ -281,6 +281,11 @@ class Client{
 		}
 		elseif($commandcmp == 'auth'){
 			$this->setStatus('hasAuth', true);
+			
+			if (empty($args)){
+				return $this->sendSyntaxErrorInParameters();
+			}
+			
 			$authentication = strtolower($args[0]);
 
 			if($authentication == 'plain'){
@@ -288,7 +293,7 @@ class Client{
 
 				if(isset($args[1])){
 					$this->setStatus('hasAuthPlainUser', true);
-					$this->setCredentials([$args[1]]);
+					$this->setCredentials(array($args[1]));
 
 					return $this->authenticate('plain');
 				}
@@ -377,6 +382,9 @@ class Client{
 		return $output;
 	}
 	
+	/**
+	 * @codeCoverageIgnore
+	 */
 	public function authenticate($type){
 		$attempt = $this->getServer()->authenticateUser($type, $this->getCredentials());
 		

--- a/src/TheFox/Smtp/Event.php
+++ b/src/TheFox/Smtp/Event.php
@@ -5,6 +5,7 @@ namespace TheFox\Smtp;
 class Event{
 	
 	const TRIGGER_MAIL_NEW = 1000;
+	const TRIGGER_AUTH_ATTEMPT = 9000;
 	
 	private $trigger = null;
 	private $object = null;

--- a/src/TheFox/Smtp/Server.php
+++ b/src/TheFox/Smtp/Server.php
@@ -21,12 +21,22 @@ class Server extends Thread{
 	private $clients = array();
 	private $eventsId = 0;
 	private $events = array();
+	private $hostname;
 	
-	public function __construct($ip = '127.0.0.1', $port = 20025){
+	public function __construct($ip = '127.0.0.1', $port = 20025, $hostname = 'localhost.localdomain'){
 		#print __CLASS__.'->'.__FUNCTION__.''."\n";
 		
 		$this->setIp($ip);
 		$this->setPort($port);
+		$this->setHostname($hostname);
+	}
+	
+	public function getHostname(){
+		return $this->hostname;
+	}
+	
+	public function setHostname($hostname){
+		$this->hostname = $hostname;
 	}
 	
 	public function setLog($log){
@@ -193,7 +203,7 @@ class Server extends Thread{
 		$this->clientsId++;
 		#print __CLASS__.'->'.__FUNCTION__.' ID: '.$this->clientsId."\n";
 		
-		$client = new Client();
+		$client = new Client($this->getHostname());
 		$client->setSocket($socket);
 		$client->setId($this->clientsId);
 		$client->setServer($this);
@@ -239,7 +249,7 @@ class Server extends Thread{
 		foreach($this->events as $eventId => $event){
 			#fwrite(STDOUT, __CLASS__.'->'.__FUNCTION__.' event: '.$eventId."\n");
 			if($event->getTrigger() == $trigger){
-				$event->execute($args);
+				return $event->execute($args);
 			}
 		}
 	}
@@ -250,6 +260,10 @@ class Server extends Thread{
 		#$this->log->debug("\n".$mail);
 		
 		$this->eventExecute(Event::TRIGGER_MAIL_NEW, array($from, $rcpt, $mail));
+	}
+	
+	public function authenticateUser($type, $credentials = array()){
+		return $this->eventExecute(Event::TRIGGER_AUTH_ATTEMPT, array($type, $credentials));
 	}
 	
 }

--- a/src/TheFox/Smtp/Server.php
+++ b/src/TheFox/Smtp/Server.php
@@ -274,12 +274,11 @@ class Server extends Thread{
 		
 		foreach($this->events as $eventId => $event){
 			if($event->getTrigger() == Event::TRIGGER_AUTH_ATTEMPT){
-				if($event->execute($args)){
-					$authenticated = true;
+				if(!$event->execute($args)){
+					return false;
 				}
-				else{
-					$authenticated = false;
-				}
+				
+				$authenticated = true;
 			}
 		}
 		

--- a/src/TheFox/Smtp/Server.php
+++ b/src/TheFox/Smtp/Server.php
@@ -249,7 +249,7 @@ class Server extends Thread{
 		foreach($this->events as $eventId => $event){
 			#fwrite(STDOUT, __CLASS__.'->'.__FUNCTION__.' event: '.$eventId."\n");
 			if($event->getTrigger() == $trigger){
-				return $event->execute($args);
+				$event->execute($args);
 			}
 		}
 	}
@@ -262,8 +262,28 @@ class Server extends Thread{
 		$this->eventExecute(Event::TRIGGER_MAIL_NEW, array($from, $rcpt, $mail));
 	}
 	
-	public function authenticateUser($type, $credentials = array()){
-		return $this->eventExecute(Event::TRIGGER_AUTH_ATTEMPT, array($type, $credentials));
+	/**
+	 * Execute authentication events
+	 * 
+	 * All authentication events must return true for authentication to be successful
+	 * 
+	 */
+	public function authenticateUser($method, $credentials = array()){
+		$authenticated = false;
+		$args = array($method, $credentials);
+		
+		foreach($this->events as $eventId => $event){
+			if($event->getTrigger() == Event::TRIGGER_AUTH_ATTEMPT){
+				if($event->execute($args)){
+					$authenticated = true;
+				}
+				else{
+					$authenticated = false;
+				}
+			}
+		}
+		
+		return $authenticated;
 	}
 	
 }

--- a/tests/TheFox/Test/ClientTest.php
+++ b/tests/TheFox/Test/ClientTest.php
@@ -166,24 +166,24 @@ class ClientTest extends PHPUnit_Framework_TestCase{
 		$server->setLog(new Logger('test_application'));
 		$server->init();
 		
-		$client = $this->getMockBuilder(Client::class)->setMethods(array('authenticate'))->getMock();
+		$client = $this->getMock('TheFox\Smtp\Client', array('authenticate'));
 		
 		$client->expects($this->at(0))
 				->method('authenticate')
 				->with('plain')
-				->will($this->returnValue('535 Authentication credentials invalid'.Client::MSG_SEPARATOR));
+				->will($this->returnValue(false));
 		$client->expects($this->at(1))
 				->method('authenticate')
 				->with('plain')
-				->will($this->returnValue('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR));
+				->will($this->returnValue(true));
 		$client->expects($this->at(2))
 				->method('authenticate')
 				->with('plain')
-				->will($this->returnValue('535 Authentication credentials invalid'.Client::MSG_SEPARATOR));
+				->will($this->returnValue(false));
 		$client->expects($this->at(3))
 				->method('authenticate')
 				->with('plain')
-				->will($this->returnValue('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR));
+				->will($this->returnValue(true));
 		
 		$client->setServer($server);
 		$client->setId(1);
@@ -195,6 +195,12 @@ class ClientTest extends PHPUnit_Framework_TestCase{
 		$this->assertEquals($expect, $msg);
 		
 		$msg = $client->msgHandle('AUTH');
+		$this->assertEquals('501 Syntax error in parameters or arguments'.Client::MSG_SEPARATOR, $msg);
+		
+		$msg = $client->msgHandle('AUTH CRAM-MD5');
+		$this->assertEquals('502 Command not implemented'.Client::MSG_SEPARATOR, $msg);
+		
+		$msg = $client->msgHandle('AUTH UNKOWN');
 		$this->assertEquals('501 Syntax error in parameters or arguments'.Client::MSG_SEPARATOR, $msg);
 		
 		$msg = $client->msgHandle('AUTH PLAIN');
@@ -219,16 +225,16 @@ class ClientTest extends PHPUnit_Framework_TestCase{
 		$server->setLog(new Logger('test_application'));
 		$server->init();
 		
-		$client = $this->getMockBuilder(Client::class)->setMethods(array('authenticate'))->getMock();
+		$client = $this->getMock('TheFox\Smtp\Client', array('authenticate'));
 		
 		$client->expects($this->at(0))
 				->method('authenticate')
 				->with('login')
-				->will($this->returnValue('535 Authentication credentials invalid'.Client::MSG_SEPARATOR));
+				->will($this->returnValue(false));
 		$client->expects($this->at(1))
 				->method('authenticate')
 				->with('login')
-				->will($this->returnValue('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR));
+				->will($this->returnValue(true));
 
 		$client->setServer($server);
 		$client->setId(1);

--- a/tests/TheFox/Test/ClientTest.php
+++ b/tests/TheFox/Test/ClientTest.php
@@ -86,9 +86,9 @@ class ClientTest extends PHPUnit_Framework_TestCase{
 		$this->assertEquals('250 localhost.localdomain'.Client::MSG_SEPARATOR, $msg);
 		
 		$msg = $client->msgHandle('EHLO localhost.localdomain');
-		$expect = '250-localhost.localdomain'.Client::MSG_SEPARATOR
-			.'250-AUTH PLAIN LOGIN'.Client::MSG_SEPARATOR
-			.'250 HELP'.Client::MSG_SEPARATOR;
+		$expect = '250-localhost.localdomain'.Client::MSG_SEPARATOR;
+		$expect .= '250-AUTH PLAIN LOGIN'.Client::MSG_SEPARATOR;
+		$expect .= '250 HELP'.Client::MSG_SEPARATOR;
 		$this->assertEquals($expect, $msg);
 		
 		$msg = $client->msgHandle('XYZ abc');
@@ -189,9 +189,9 @@ class ClientTest extends PHPUnit_Framework_TestCase{
 		$client->setId(1);
 		
 		$msg = $client->msgHandle('EHLO localhost.localdomain');
-		$expect = '250-localhost.localdomain'.Client::MSG_SEPARATOR
-			.'250-AUTH PLAIN LOGIN'.Client::MSG_SEPARATOR
-			.'250 HELP'.Client::MSG_SEPARATOR;
+		$expect = '250-localhost.localdomain'.Client::MSG_SEPARATOR;
+		$expect .= '250-AUTH PLAIN LOGIN'.Client::MSG_SEPARATOR;
+		$expect .= '250 HELP'.Client::MSG_SEPARATOR;
 		$this->assertEquals($expect, $msg);
 		
 		$msg = $client->msgHandle('AUTH');
@@ -234,9 +234,9 @@ class ClientTest extends PHPUnit_Framework_TestCase{
 		$client->setId(1);
 		
 		$msg = $client->msgHandle('EHLO localhost.localdomain');
-		$expect = '250-localhost.localdomain'.Client::MSG_SEPARATOR
-			.'250-AUTH PLAIN LOGIN'.Client::MSG_SEPARATOR
-			.'250 HELP'.Client::MSG_SEPARATOR;
+		$expect = '250-localhost.localdomain'.Client::MSG_SEPARATOR;
+		$expect .= '250-AUTH PLAIN LOGIN'.Client::MSG_SEPARATOR;
+		$expect .= '250 HELP'.Client::MSG_SEPARATOR;
 		$this->assertEquals($expect, $msg);
 		
 		$msg = $client->msgHandle('AUTH');

--- a/tests/TheFox/Test/ClientTest.php
+++ b/tests/TheFox/Test/ClientTest.php
@@ -169,21 +169,21 @@ class ClientTest extends PHPUnit_Framework_TestCase{
 		$client = $this->getMockBuilder(Client::class)->setMethods(array('authenticate'))->getMock();
 		
 		$client->expects($this->at(0))
-			->method('authenticate')
-			->with('plain')
-			->will($this->returnValue('535 Authentication credentials invalid'.Client::MSG_SEPARATOR));
+				->method('authenticate')
+				->with('plain')
+				->will($this->returnValue('535 Authentication credentials invalid'.Client::MSG_SEPARATOR));
 		$client->expects($this->at(1))
-			->method('authenticate')
-			->with('plain')
-			->will($this->returnValue('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR));
+				->method('authenticate')
+				->with('plain')
+				->will($this->returnValue('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR));
 		$client->expects($this->at(2))
-			->method('authenticate')
-			->with('plain')
-			->will($this->returnValue('535 Authentication credentials invalid'.Client::MSG_SEPARATOR));
+				->method('authenticate')
+				->with('plain')
+				->will($this->returnValue('535 Authentication credentials invalid'.Client::MSG_SEPARATOR));
 		$client->expects($this->at(3))
-			->method('authenticate')
-			->with('plain')
-			->will($this->returnValue('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR));
+				->method('authenticate')
+				->with('plain')
+				->will($this->returnValue('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR));
 		
 		$client->setServer($server);
 		$client->setId(1);
@@ -222,13 +222,13 @@ class ClientTest extends PHPUnit_Framework_TestCase{
 		$client = $this->getMockBuilder(Client::class)->setMethods(array('authenticate'))->getMock();
 		
 		$client->expects($this->at(0))
-			->method('authenticate')
-			->with('login')
-			->will($this->returnValue('535 Authentication credentials invalid'.Client::MSG_SEPARATOR));
+				->method('authenticate')
+				->with('login')
+				->will($this->returnValue('535 Authentication credentials invalid'.Client::MSG_SEPARATOR));
 		$client->expects($this->at(1))
-			->method('authenticate')
-			->with('login')
-			->will($this->returnValue('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR));
+				->method('authenticate')
+				->with('login')
+				->will($this->returnValue('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR));
 
 		$client->setServer($server);
 		$client->setId(1);

--- a/tests/TheFox/Test/ClientTest.php
+++ b/tests/TheFox/Test/ClientTest.php
@@ -86,7 +86,10 @@ class ClientTest extends PHPUnit_Framework_TestCase{
 		$this->assertEquals('250 localhost.localdomain'.Client::MSG_SEPARATOR, $msg);
 		
 		$msg = $client->msgHandle('EHLO localhost.localdomain');
-		$this->assertEquals('250-localhost.localdomain'.Client::MSG_SEPARATOR.'250-AUTH PLAIN LOGIN'.Client::MSG_SEPARATOR.'250 HELP'.Client::MSG_SEPARATOR, $msg);
+		$expect = '250-localhost.localdomain'.Client::MSG_SEPARATOR
+			.'250-AUTH PLAIN LOGIN'.Client::MSG_SEPARATOR
+			.'250 HELP'.Client::MSG_SEPARATOR;
+		$this->assertEquals($expect, $msg);
 		
 		$msg = $client->msgHandle('XYZ abc');
 		$this->assertEquals('500 Syntax error, command unrecognized'.Client::MSG_SEPARATOR, $msg);
@@ -165,16 +168,31 @@ class ClientTest extends PHPUnit_Framework_TestCase{
 		
 		$client = $this->getMockBuilder(Client::class)->setMethods(array('authenticate'))->getMock();
 		
-		$client->expects($this->at(0))->method('authenticate')->with('plain')->will($this->returnValue('535 Authentication credentials invalid'.Client::MSG_SEPARATOR));
-		$client->expects($this->at(1))->method('authenticate')->with('plain')->will($this->returnValue('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR));
-		$client->expects($this->at(2))->method('authenticate')->with('plain')->will($this->returnValue('535 Authentication credentials invalid'.Client::MSG_SEPARATOR));
-		$client->expects($this->at(3))->method('authenticate')->with('plain')->will($this->returnValue('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR));
+		$client->expects($this->at(0))
+			->method('authenticate')
+			->with('plain')
+			->will($this->returnValue('535 Authentication credentials invalid'.Client::MSG_SEPARATOR));
+		$client->expects($this->at(1))
+			->method('authenticate')
+			->with('plain')
+			->will($this->returnValue('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR));
+		$client->expects($this->at(2))
+			->method('authenticate')
+			->with('plain')
+			->will($this->returnValue('535 Authentication credentials invalid'.Client::MSG_SEPARATOR));
+		$client->expects($this->at(3))
+			->method('authenticate')
+			->with('plain')
+			->will($this->returnValue('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR));
 		
 		$client->setServer($server);
 		$client->setId(1);
 		
 		$msg = $client->msgHandle('EHLO localhost.localdomain');
-		$this->assertEquals('250-localhost.localdomain'.Client::MSG_SEPARATOR.'250-AUTH PLAIN LOGIN'.Client::MSG_SEPARATOR.'250 HELP'.Client::MSG_SEPARATOR, $msg);
+		$expect = '250-localhost.localdomain'.Client::MSG_SEPARATOR
+			.'250-AUTH PLAIN LOGIN'.Client::MSG_SEPARATOR
+			.'250 HELP'.Client::MSG_SEPARATOR;
+		$this->assertEquals($expect, $msg);
 		
 		$msg = $client->msgHandle('AUTH');
 		$this->assertEquals('501 Syntax error in parameters or arguments'.Client::MSG_SEPARATOR, $msg);
@@ -203,14 +221,23 @@ class ClientTest extends PHPUnit_Framework_TestCase{
 		
 		$client = $this->getMockBuilder(Client::class)->setMethods(array('authenticate'))->getMock();
 		
-		$client->expects($this->at(0))->method('authenticate')->with('login')->will($this->returnValue('535 Authentication credentials invalid'.Client::MSG_SEPARATOR));
-		$client->expects($this->at(1))->method('authenticate')->with('login')->will($this->returnValue('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR));
+		$client->expects($this->at(0))
+			->method('authenticate')
+			->with('login')
+			->will($this->returnValue('535 Authentication credentials invalid'.Client::MSG_SEPARATOR));
+		$client->expects($this->at(1))
+			->method('authenticate')
+			->with('login')
+			->will($this->returnValue('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR));
 
 		$client->setServer($server);
 		$client->setId(1);
 		
 		$msg = $client->msgHandle('EHLO localhost.localdomain');
-		$this->assertEquals('250-localhost.localdomain'.Client::MSG_SEPARATOR.'250-AUTH PLAIN LOGIN'.Client::MSG_SEPARATOR.'250 HELP'.Client::MSG_SEPARATOR, $msg);
+		$expect = '250-localhost.localdomain'.Client::MSG_SEPARATOR
+			.'250-AUTH PLAIN LOGIN'.Client::MSG_SEPARATOR
+			.'250 HELP'.Client::MSG_SEPARATOR;
+		$this->assertEquals($expect, $msg);
 		
 		$msg = $client->msgHandle('AUTH');
 		$this->assertEquals('501 Syntax error in parameters or arguments'.Client::MSG_SEPARATOR, $msg);

--- a/tests/TheFox/Test/ClientTest.php
+++ b/tests/TheFox/Test/ClientTest.php
@@ -58,6 +58,20 @@ class ClientTest extends PHPUnit_Framework_TestCase{
 		$this->assertEquals(null, $log);
 	}
 	
+	public function testGetCredentials(){
+		$client = new Client();
+		$client->setCredentials(array('user' => 'testuser', 'password' => 'super_secret_password'));
+		$credentials = $client->getCredentials();
+		$this->assertEquals('testuser', $credentials['user']);
+		$this->assertEquals('super_secret_password', $credentials['password']);
+	}
+	
+	public function testGetHostname(){
+		$client = new Client();
+		$host = $client->getHostname();
+		$this->assertEquals('localhost.localdomain', $host);
+	}
+	
 	public function testMsgHandleHello(){
 		$server = new Server('', 0);
 		$server->setLog(new Logger('test_application'));
@@ -72,7 +86,7 @@ class ClientTest extends PHPUnit_Framework_TestCase{
 		$this->assertEquals('250 localhost.localdomain'.Client::MSG_SEPARATOR, $msg);
 		
 		$msg = $client->msgHandle('EHLO localhost.localdomain');
-		$this->assertEquals('502 Command not implemented'.Client::MSG_SEPARATOR, $msg);
+		$this->assertEquals('250-localhost.localdomain'.Client::MSG_SEPARATOR.'250-AUTH PLAIN LOGIN'.Client::MSG_SEPARATOR.'250 HELP'.Client::MSG_SEPARATOR, $msg);
 		
 		$msg = $client->msgHandle('XYZ abc');
 		$this->assertEquals('500 Syntax error, command unrecognized'.Client::MSG_SEPARATOR, $msg);
@@ -88,6 +102,7 @@ class ClientTest extends PHPUnit_Framework_TestCase{
 		$client->setId(1);
 		
 		
+		
 		$msg = $client->msgHandle('MAIL FROM:<Smith@Alpha.ARPA>');
 		$this->assertEquals('500 Syntax error, command unrecognized'.Client::MSG_SEPARATOR, $msg);
 		
@@ -100,7 +115,6 @@ class ClientTest extends PHPUnit_Framework_TestCase{
 		
 		$msg = $client->msgHandle('HELO localhost.localdomain');
 		$this->assertEquals('250 localhost.localdomain'.Client::MSG_SEPARATOR, $msg);
-		
 		
 		$msg = $client->msgHandle('MAIL');
 		$this->assertEquals('501 Syntax error in parameters or arguments'.Client::MSG_SEPARATOR, $msg);
@@ -134,11 +148,87 @@ class ClientTest extends PHPUnit_Framework_TestCase{
 		$msg = $client->msgHandle('.');
 		$this->assertEquals('250 OK'.Client::MSG_SEPARATOR, $msg);
 		
+		$msg = $client->msgHandle('HELP');
+		$this->assertEquals('250 HELO, EHLO, MAIL FROM, RCPT TO, DATA, NOOP, QUIT'.Client::MSG_SEPARATOR, $msg);
+		
 		$msg = $client->msgHandle('NOOP');
 		$this->assertEquals('250 OK'.Client::MSG_SEPARATOR, $msg);
 		
 		$msg = $client->msgHandle('QUIT');
 		$this->assertEquals('221 localhost.localdomain Service closing transmission channel'.Client::MSG_SEPARATOR, $msg);
+	}
+	
+	public function testMsgHandleAuthPlain(){
+		$server = new Server('', 0);
+		$server->setLog(new Logger('test_application'));
+		$server->init();
+		
+		$client = $this->getMockBuilder(Client::class)->setMethods(array('authenticate'))->getMock();
+		
+		$client->expects($this->at(0))->method('authenticate')->with('plain')->will($this->returnValue('535 Authentication credentials invalid'.Client::MSG_SEPARATOR));
+		$client->expects($this->at(1))->method('authenticate')->with('plain')->will($this->returnValue('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR));
+		$client->expects($this->at(2))->method('authenticate')->with('plain')->will($this->returnValue('535 Authentication credentials invalid'.Client::MSG_SEPARATOR));
+		$client->expects($this->at(3))->method('authenticate')->with('plain')->will($this->returnValue('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR));
+		
+		$client->setServer($server);
+		$client->setId(1);
+		
+		$msg = $client->msgHandle('EHLO localhost.localdomain');
+		$this->assertEquals('250-localhost.localdomain'.Client::MSG_SEPARATOR.'250-AUTH PLAIN LOGIN'.Client::MSG_SEPARATOR.'250 HELP'.Client::MSG_SEPARATOR, $msg);
+		
+		$msg = $client->msgHandle('AUTH');
+		$this->assertEquals('501 Syntax error in parameters or arguments'.Client::MSG_SEPARATOR, $msg);
+		
+		$msg = $client->msgHandle('AUTH PLAIN');
+		$this->assertEquals('334 '.Client::MSG_SEPARATOR, $msg);
+		
+		// base64 encoded PLAIN username and password
+		$msg = $client->msgHandle(base64_encode('usertestusersuper_secret_password'));
+		$this->assertEquals('535 Authentication credentials invalid'.Client::MSG_SEPARATOR, $msg);
+		
+		$msg = $client->msgHandle(base64_encode('usertestusersuper_secret_password'));
+		$this->assertEquals('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR, $msg);
+		
+		$msg = $client->msgHandle('AUTH PLAIN '.base64_encode('usertestusersuper_secret_password'));
+		$this->assertEquals('535 Authentication credentials invalid'.Client::MSG_SEPARATOR, $msg);
+		
+		$msg = $client->msgHandle('AUTH PLAIN '.base64_encode('usertestusersuper_secret_password'));
+		$this->assertEquals('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR, $msg);
+	}
+	
+	public function testMsgHandleAuthLogin(){
+		$server = new Server('', 0);
+		$server->setLog(new Logger('test_application'));
+		$server->init();
+		
+		$client = $this->getMockBuilder(Client::class)->setMethods(array('authenticate'))->getMock();
+		
+		$client->expects($this->at(0))->method('authenticate')->with('login')->will($this->returnValue('535 Authentication credentials invalid'.Client::MSG_SEPARATOR));
+		$client->expects($this->at(1))->method('authenticate')->with('login')->will($this->returnValue('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR));
+
+		$client->setServer($server);
+		$client->setId(1);
+		
+		$msg = $client->msgHandle('EHLO localhost.localdomain');
+		$this->assertEquals('250-localhost.localdomain'.Client::MSG_SEPARATOR.'250-AUTH PLAIN LOGIN'.Client::MSG_SEPARATOR.'250 HELP'.Client::MSG_SEPARATOR, $msg);
+		
+		$msg = $client->msgHandle('AUTH');
+		$this->assertEquals('501 Syntax error in parameters or arguments'.Client::MSG_SEPARATOR, $msg);
+		
+		$msg = $client->msgHandle('AUTH LOGIN');
+		$this->assertEquals('334 '.base64_encode('Username:').Client::MSG_SEPARATOR, $msg);
+		
+		// base64 encoded LOGIN username
+		$msg = $client->msgHandle(base64_encode('testuser'));
+		$this->assertEquals('334 '.base64_encode('Password:').Client::MSG_SEPARATOR, $msg);
+		
+		// base64 encoded LOGIN password
+		$msg = $client->msgHandle(base64_encode('super_secret_password'));
+		$this->assertEquals('535 Authentication credentials invalid'.Client::MSG_SEPARATOR, $msg);
+		
+		// base64 encoded LOGIN password
+		$msg = $client->msgHandle(base64_encode('super_secret_password'));
+		$this->assertEquals('235 2.7.0 Authentication successful'.Client::MSG_SEPARATOR, $msg);
 	}
 	
 }

--- a/tests/TheFox/Test/ServerTest.php
+++ b/tests/TheFox/Test/ServerTest.php
@@ -144,17 +144,21 @@ class ServerTest extends PHPUnit_Framework_TestCase{
 		
 		$testData = 21;
 		$phpunit = $this;
-		$event1 = new Event(Event::TRIGGER_AUTH_ATTEMPT, null, function($event, $type, $credentials) use($phpunit, &$testData, $username, $password) {
-			#fwrite(STDOUT, 'my function: '.$event->getTrigger().', '.$testData."\n");
-			$testData = 24;
-			
-			$phpunit->assertEquals('LOGIN', $type);
-			
-			$phpunit->assertEquals(base64_encode($username), $credentials['user']);
-			$phpunit->assertEquals(base64_encode($password), $credentials['password']);
-			
-			return 42;
-		});
+		$event1 = new Event(
+			Event::TRIGGER_AUTH_ATTEMPT,
+			null,
+			function($event, $type, $credentials) use($phpunit, &$testData, $username, $password) {
+				#fwrite(STDOUT, 'my function: '.$event->getTrigger().', '.$testData."\n");
+				$testData = 24;
+				
+				$phpunit->assertEquals('LOGIN', $type);
+				
+				$phpunit->assertEquals(base64_encode($username), $credentials['user']);
+				$phpunit->assertEquals(base64_encode($password), $credentials['password']);
+				
+				return 42;
+			}
+		);
 		$server->eventAdd($event1);
 		
 		$testObj = new TestObj();

--- a/tests/TheFox/Test/ServerTest.php
+++ b/tests/TheFox/Test/ServerTest.php
@@ -142,37 +142,37 @@ class ServerTest extends PHPUnit_Framework_TestCase{
 		$username = 'testuser';
 		$password = 'super_secret_password';
 		
-		$testData = 21;
+		$testData = false;
 		$phpunit = $this;
 		$event1 = new Event(
 			Event::TRIGGER_AUTH_ATTEMPT,
 			null,
-			function($event, $type, $credentials) use($phpunit, &$testData, $username, $password) {
+			function($event, $method, $credentials) use($phpunit, &$testData, $username, $password) {
 				#fwrite(STDOUT, 'my function: '.$event->getTrigger().', '.$testData."\n");
-				$testData = 24;
+				$testData = true;
 				
-				$phpunit->assertEquals('LOGIN', $type);
+				$phpunit->assertEquals('LOGIN', $method);
 				
 				$phpunit->assertEquals(base64_encode($username), $credentials['user']);
 				$phpunit->assertEquals(base64_encode($password), $credentials['password']);
 				
-				return 42;
+				return false;
 			}
 		);
 		$server->eventAdd($event1);
 		
 		$testObj = new TestObj();
-		$event2 = new Event(Event::TRIGGER_AUTH_ATTEMPT, $testObj, 'test1');
+		$event2 = new Event(Event::TRIGGER_AUTH_ATTEMPT, $testObj, 'test2');
 		$server->eventAdd($event2);
 		
-		$type = 'LOGIN';
+		$method = 'LOGIN';
 		$credentials = array('user' => base64_encode($username), 'password' => base64_encode($password));
 		
-		$server->authenticateUser($type, $credentials);
+		$server->authenticateUser($method, $credentials);
 		
-		$this->assertEquals(24, $testData);
-		$this->assertEquals(42, $event1->getReturnValue());
-		$this->assertEquals(43, $event2->getReturnValue());
+		$this->assertTrue($testData);
+		$this->assertFalse($event1->getReturnValue());
+		$this->assertTrue($event2->getReturnValue());
 	}
 	
 }

--- a/tests/TheFox/Test/ServerTest.php
+++ b/tests/TheFox/Test/ServerTest.php
@@ -134,4 +134,41 @@ class ServerTest extends PHPUnit_Framework_TestCase{
 		$this->assertEquals(43, $event2->getReturnValue());
 	}
 	
+	public function testEventAuth(){
+		$server = new Server('', 0);
+		$server->setLog(new Logger('test_application'));
+		$server->init();
+		
+		$username = 'testuser';
+		$password = 'super_secret_password';
+		
+		$testData = 21;
+		$phpunit = $this;
+		$event1 = new Event(Event::TRIGGER_AUTH_ATTEMPT, null, function($event, $type, $credentials) use($phpunit, &$testData, $username, $password) {
+			#fwrite(STDOUT, 'my function: '.$event->getTrigger().', '.$testData."\n");
+			$testData = 24;
+			
+			$phpunit->assertEquals('LOGIN', $type);
+			
+			$phpunit->assertEquals(base64_encode($username), $credentials['user']);
+			$phpunit->assertEquals(base64_encode($password), $credentials['password']);
+			
+			return 42;
+		});
+		$server->eventAdd($event1);
+		
+		$testObj = new TestObj();
+		$event2 = new Event(Event::TRIGGER_AUTH_ATTEMPT, $testObj, 'test1');
+		$server->eventAdd($event2);
+		
+		$type = 'LOGIN';
+		$credentials = array('user' => base64_encode($username), 'password' => base64_encode($password));
+		
+		$server->authenticateUser($type, $credentials);
+		
+		$this->assertEquals(24, $testData);
+		$this->assertEquals(42, $event1->getReturnValue());
+		$this->assertEquals(43, $event2->getReturnValue());
+	}
+	
 }

--- a/tests/TheFox/Test/TestObj.php
+++ b/tests/TheFox/Test/TestObj.php
@@ -11,4 +11,9 @@ class TestObj{
 		return 43;
 	}
 	
+	public function test2($event, $method, $credentials){
+		#fwrite(STDOUT, 'my function: '.$event->getTrigger()."\n");
+		return true;
+	}
+	
 }


### PR DESCRIPTION
I have added the extended SMTP command AUTH with the login methods PLAIN and LOGIN.

When a client tries to authenticate with the server an event is triggered (Event::TRIGGER_AUTH_ATTEMPT) which passes login type and the clients credentials.

If PLAIN is used then the username and password are concatenated, prepend with _user_ and then base64 encoded.  The `$credentials` parameter is an array with this base64 encoded string.

If LOGIN is used then the username and password are sent separately as base64 encoded strings. The `$credentials` parameter is an associative array with the key `user` for the base64 encoded username and the key `password` with the base64 encoded password.
