### PR TITLE
add ESMTP STARTTLS command

### DIFF
--- a/src/TheFox/Network/StreamSocket.php
+++ b/src/TheFox/Network/StreamSocket.php
@@ -20,7 +20,7 @@ class StreamSocket extends AbstractSocket{
 	
 	public function listen($contextOptions = array()){
 		$local_socket = 'tcp://'.$this->ip.':'.$this->port;
-		$flags = STREAM_SERVER_BIND|STREAM_SERVER_LISTEN;
+		$flags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
 		$context = stream_context_create($contextOptions);
 		$handle = @stream_socket_server($local_socket, $errno, $errstr, $flags, $context);
 		
@@ -59,7 +59,7 @@ class StreamSocket extends AbstractSocket{
 	public function enableEncryption(){
 		$crypto_method = STREAM_CRYPTO_METHOD_TLS_SERVER;
 		
-		if (defined('STREAM_CRYPTO_METHOD_TLSv1_2_SERVER')) {
+		if(defined('STREAM_CRYPTO_METHOD_TLSv1_2_SERVER')){
 			$crypto_method |= STREAM_CRYPTO_METHOD_TLSv1_2_SERVER;
 			$crypto_method |= STREAM_CRYPTO_METHOD_TLSv1_1_SERVER;
 		}

--- a/src/TheFox/Network/StreamSocket.php
+++ b/src/TheFox/Network/StreamSocket.php
@@ -18,8 +18,12 @@ class StreamSocket extends AbstractSocket{
 		return true;
 	}
 	
-	public function listen(){
-		$handle = @stream_socket_server('tcp://'.$this->ip.':'.$this->port, $errno, $errstr);
+	public function listen($contextOptions = array()){
+		$local_socket = 'tcp://'.$this->ip.':'.$this->port;
+		$flags = STREAM_SERVER_BIND|STREAM_SERVER_LISTEN;
+		$context = stream_context_create($contextOptions);
+		$handle = @stream_socket_server($local_socket, $errno, $errstr, $flags, $context);
+		
 		if($handle !== false){
 			$this->setHandle($handle);
 			return true;
@@ -50,6 +54,25 @@ class StreamSocket extends AbstractSocket{
 			$socket->setHandle($handle);
 		}
 		return $socket;
+	}
+	
+	public function enableEncryption(){
+		$crypto_method = STREAM_CRYPTO_METHOD_TLS_SERVER;
+		
+		if (defined('STREAM_CRYPTO_METHOD_TLSv1_2_SERVER')) {
+			$crypto_method |= STREAM_CRYPTO_METHOD_TLSv1_2_SERVER;
+			$crypto_method |= STREAM_CRYPTO_METHOD_TLSv1_1_SERVER;
+		}
+		
+		stream_set_blocking ($this->getHandle(), true);
+		$result = @stream_socket_enable_crypto($this->getHandle(), true, $crypto_method);
+		stream_set_blocking ($this->getHandle(), false);
+		
+		if($result === false){
+			throw new RuntimeException('TLS negotiation has failed');
+		}
+		
+		return true;
 	}
 	
 	public function select(&$readHandles, &$writeHandles, &$exceptHandles){
@@ -84,11 +107,11 @@ class StreamSocket extends AbstractSocket{
 	}
 	
 	public function read(){
-		return stream_socket_recvfrom($this->getHandle(), 2048);
+		return fread($this->getHandle(), 2048);
 	}
 	
 	public function write($data){
-		$rv = @stream_socket_sendto($this->getHandle(), $data);
+		$rv = @fwrite($this->getHandle(), $data);
 		
 		#print __CLASS__.'->'.__FUNCTION__.': '.$rv.', "'.substr($data, 0, -1).'"'."\n";
 		return $rv;

--- a/src/TheFox/Smtp/Client.php
+++ b/src/TheFox/Smtp/Client.php
@@ -29,7 +29,7 @@ class Client{
 	private $mail = '';
 	private $hostname = '';
 	private $credentials = array();
-	private $extended_commands = array('AUTH PLAIN LOGIN', 'HELP');
+	private $extended_commands = array('AUTH PLAIN LOGIN', 'STARTTLS', 'HELP');
 	
 	public function __construct($hostname){
 		#print __CLASS__.'->'.__FUNCTION__.''."\n";
@@ -202,8 +202,9 @@ class Client{
 			#$this->log('debug', 'client '.$this->id.' helo');
 			$this->setStatus('hasHello', true);
 			$msg = '250-'.$this->getHostname().static::MSG_SEPARATOR;
-
-			for($i = 0; $i < count($this->extended_commands); $i++){
+			$count = count($this->extended_commands) - 1;
+			
+			for($i = 0; $i < $count; $i++){
 				$msg .= '250-'.$this->extended_commands[$i].static::MSG_SEPARATOR;
 			}
 
@@ -305,6 +306,11 @@ class Client{
 			else{
 				return $this->sendSyntaxErrorCommandUnrecognized();
 			}
+		}
+		elseif($commandcmp == 'starttls'){
+			$this->sendStartTls();
+			
+			return $this->getSocket()->enableEncryption();
 		}
 		elseif($commandcmp == 'help'){
 			return $this->sendOk('HELO, EHLO, MAIL FROM, RCPT TO, DATA, NOOP, QUIT');
@@ -423,6 +429,10 @@ class Client{
 	
 	private function sendAskForPasswordResponse(){
 		return $this->dataSend('334 UGFzc3dvcmQ6');
+	}
+	
+	private function sendStartTls(){
+		return $this->dataSend('220 TLS go ahead');
 	}
 	
 	private function sendSyntaxErrorCommandUnrecognized(){

--- a/src/TheFox/Smtp/Server.php
+++ b/src/TheFox/Smtp/Server.php
@@ -75,7 +75,7 @@ class Server extends Thread{
 	/**
 	 * @codeCoverageIgnore
 	 */
-	public function listen(){
+	public function listen($contextOptions){
 		if($this->ip && $this->port){
 			#$this->log->notice('listen on '.$this->ip.':'.$this->port);
 			
@@ -91,7 +91,7 @@ class Server extends Thread{
 			
 			if($bind){
 				try{
-					if($this->socket->listen()){
+					if($this->socket->listen($contextOptions)){
 						$this->log->notice('listen ok');
 						$this->isListening = true;
 						

--- a/tests/TheFox/Test/ClientTest.php
+++ b/tests/TheFox/Test/ClientTest.php
@@ -88,6 +88,7 @@ class ClientTest extends PHPUnit_Framework_TestCase{
 		$msg = $client->msgHandle('EHLO localhost.localdomain');
 		$expect = '250-localhost.localdomain'.Client::MSG_SEPARATOR;
 		$expect .= '250-AUTH PLAIN LOGIN'.Client::MSG_SEPARATOR;
+		$expect .= '250-STARTTLS'.Client::MSG_SEPARATOR;
 		$expect .= '250 HELP'.Client::MSG_SEPARATOR;
 		$this->assertEquals($expect, $msg);
 		
@@ -191,6 +192,7 @@ class ClientTest extends PHPUnit_Framework_TestCase{
 		$msg = $client->msgHandle('EHLO localhost.localdomain');
 		$expect = '250-localhost.localdomain'.Client::MSG_SEPARATOR;
 		$expect .= '250-AUTH PLAIN LOGIN'.Client::MSG_SEPARATOR;
+		$expect .= '250-STARTTLS'.Client::MSG_SEPARATOR;
 		$expect .= '250 HELP'.Client::MSG_SEPARATOR;
 		$this->assertEquals($expect, $msg);
 		
@@ -242,6 +244,7 @@ class ClientTest extends PHPUnit_Framework_TestCase{
 		$msg = $client->msgHandle('EHLO localhost.localdomain');
 		$expect = '250-localhost.localdomain'.Client::MSG_SEPARATOR;
 		$expect .= '250-AUTH PLAIN LOGIN'.Client::MSG_SEPARATOR;
+		$expect .= '250-STARTTLS'.Client::MSG_SEPARATOR;
 		$expect .= '250 HELP'.Client::MSG_SEPARATOR;
 		$this->assertEquals($expect, $msg);
 		


### PR DESCRIPTION
I have added the extended SMTP command STARTTLS.

The client can now request an encrypted connection via TLS to the server.

I have added to the `example.php` how to create a self-signed certificate and use this for the encrypted connection.

Implementation is [RFC 3207](https://tools.ietf.org/html/rfc3207).
