### PR TITLE
Add capability to reject RCPT addresses via an event handler

### DIFF
--- a/src/TheFox/Smtp/Client.php
+++ b/src/TheFox/Smtp/Client.php
@@ -344,6 +344,11 @@ class Client
                     $rcpt = $args[0];
                     if (substr(strtolower($rcpt), 0, 4) == 'to:<') {
                         $rcpt = substr(substr($rcpt, 4), 0, -1);
+
+                        $server = $this->getServer();
+                        if (!$server->newRcpt($rcpt)) {
+                            return $this->sendUserUnknown();
+                        }
                         $this->rcpt[] = $rcpt;
                     }
                     return $this->sendOk();
@@ -618,6 +623,14 @@ class Client
     private function sendAuthInvalid(): string
     {
         return $this->dataSend('535 Authentication credentials invalid');
+    }
+
+    /**
+     * @return string
+     */
+    private function sendUserUnknown(): string
+    {
+        return $this->dataSend('550 User unknown');
     }
 
     public function shutdown()

--- a/src/TheFox/Smtp/Event.php
+++ b/src/TheFox/Smtp/Event.php
@@ -10,6 +10,7 @@ class Event
 {
     const TRIGGER_NEW_MAIL = 1000;
     const TRIGGER_AUTH_ATTEMPT = 9000;
+    const TRIGGER_NEW_RCPT = 2000;
 
     /**
      * @var int

--- a/src/TheFox/Smtp/Server.php
+++ b/src/TheFox/Smtp/Server.php
@@ -65,7 +65,7 @@ class Server extends Thread
     private $eventsId = 0;
 
     /**
-     * @var array
+     * @var Event[]
      */
     private $events = [];
 
@@ -340,6 +340,22 @@ class Server extends Thread
     public function newMail(string $from, array $rcpt, Message $mail)
     {
         $this->eventExecute(Event::TRIGGER_NEW_MAIL, [$from, $rcpt, $mail]);
+    }
+
+    /**
+     * @param string $rcpt
+     * @return bool
+     */
+    public function newRcpt(string $rcpt)
+    {
+        foreach ($this->events as $eventId => $event) {
+            if ($event->getTrigger() == Event::TRIGGER_NEW_RCPT) {
+                if (!$event->execute([$rcpt])) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     /**

--- a/tests/TheFox/Test/ClientTest.php
+++ b/tests/TheFox/Test/ClientTest.php
@@ -5,7 +5,7 @@ namespace TheFox\Test;
 use RuntimeException;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
-use PHPUnit_Framework_MockObject_MockBuilder;
+use PHPUnit\Framework\MockObject\MockBuilder;
 use TheFox\Network\StreamSocket;
 use TheFox\Smtp\Event;
 use TheFox\Smtp\Server;
@@ -177,7 +177,7 @@ class ClientTest extends TestCase
     {
         $server = new Server();
 
-        /** @var PHPUnit_Framework_MockObject_MockBuilder $mockBuilder */
+        /** @var MockBuilder $mockBuilder */
         $mockBuilder = $this->getMockBuilder(Client::class);
         $mockBuilder->setMethods(['authenticate']);
         
@@ -241,7 +241,7 @@ class ClientTest extends TestCase
     {
         $server = new Server();
 
-        /** @var PHPUnit_Framework_MockObject_MockBuilder $mockBuilder */
+        /** @var MockBuilder $mockBuilder */
         $mockBuilder = $this->getMockBuilder(Client::class);
         $mockBuilder->setMethods(['authenticate']);
 
@@ -290,7 +290,7 @@ class ClientTest extends TestCase
     {
         $server = new Server();
 
-        /** @var PHPUnit_Framework_MockObject_MockBuilder $mockBuilder */
+        /** @var MockBuilder $mockBuilder */
         $mockBuilder = $this->getMockBuilder(StreamSocket::class);
         $mockBuilder->setMethods(['enableEncryption']);
 

--- a/tests/TheFox/Test/ServerTest.php
+++ b/tests/TheFox/Test/ServerTest.php
@@ -112,6 +112,21 @@ class ServerTest extends TestCase
         $this->assertEquals(43, $event2->getReturnValue());
     }
 
+    /** @dataProvider rcptProvider */
+    public function testEventNewRcpt($mail, $valid)
+    {
+        $server = new Server();
+        $phpunit = $this;
+        $event1 = new Event(Event::TRIGGER_NEW_RCPT, null, function ($event, $rcpt) use ($phpunit, $mail, $valid) {
+            $phpunit->assertEquals($mail, $rcpt);
+            return $valid;
+        });
+        $server->addEvent($event1);
+
+        $return = $server->newRcpt($mail);
+        $this->assertEquals($valid, $return);
+    }
+    
     public function testEventAuthWithFalse()
     {
         $server = new Server();
@@ -169,5 +184,13 @@ class ServerTest extends TestCase
         $authenticated = $server->authenticateUser($method, $credentials);
 
         $this->assertTrue($authenticated);
+    }
+
+    public function rcptProvider()
+    {
+        return [
+            'valid' => ['valid@example.com', true],
+            'invalid' => ['invalid@example.com', false],
+        ];
     }
 }


### PR DESCRIPTION
My use case for SMTPD is to be able to specify some addresses to reject with a 550 message in order to test an application that has some behaviour resulting from a bounced address.

This pull request allows an event handler to be registered with the server that can be used to filter the addresses that are accepted.