### PR TITLE
Ensure separator broken over multiple packets doesn't break smtpd

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -274,19 +274,23 @@ class Client
 
         do {
             $separatorPos = strpos($data, static::MSG_SEPARATOR);
+            $separatorLen = strlen(static::MSG_SEPARATOR);
+            // handle separators broken over multiple recvs
+            if (($separatorPos === false) && $this->recvBufferTmp) {
+                $separatorPos = strpos( substr($this->recvBufferTmp, -$separatorLen) . substr($data, 0, $separatorLen), static::MSG_SEPARATOR) - $separatorLen;
+            }
             if ($separatorPos === false) {
                 $this->recvBufferTmp .= $data;
 
                 $this->logger->debug('client ' . $this->id . ': collect data');
-
                 break;
             } else {
-                $msg = $this->recvBufferTmp . substr($data, 0, $separatorPos);
+                $msg = substr($this->recvBufferTmp . $data, 0, strlen($this->recvBufferTmp) + $separatorPos);
                 $this->recvBufferTmp = '';
 
                 $this->handleMessage($msg);
 
-                $data = substr($data, $separatorPos + strlen(static::MSG_SEPARATOR));
+                $data = substr($data, $separatorPos + $separatorLen);
             }
         } while ($data);
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -277,7 +277,10 @@ class Client
             $separatorLen = strlen(static::MSG_SEPARATOR);
             // handle separators broken over multiple recvs
             if (($separatorPos === false) && $this->recvBufferTmp) {
-                $separatorPos = strpos( substr($this->recvBufferTmp, -$separatorLen) . substr($data, 0, $separatorLen), static::MSG_SEPARATOR) - $separatorLen;
+                $separatorPos = strpos(
+                    substr($this->recvBufferTmp, -$separatorLen) .substr($data, 0, $separatorLen),
+                    static::MSG_SEPARATOR
+                ) - $separatorLen;
             }
             if ($separatorPos === false) {
                 $this->recvBufferTmp .= $data;
@@ -285,7 +288,11 @@ class Client
                 $this->logger->debug('client ' . $this->id . ': collect data');
                 break;
             } else {
-                $msg = substr($this->recvBufferTmp . $data, 0, strlen($this->recvBufferTmp) + $separatorPos);
+                $msg = substr(
+                    $this->recvBufferTmp . $data,
+                    0,
+                    strlen($this->recvBufferTmp) + $separatorPos
+                );
                 $this->recvBufferTmp = '';
 
                 $this->handleMessage($msg);


### PR DESCRIPTION
Where the `\r` and the `\n` of the `Client::MSG_SEPARATOR` string appear in separate packets received from a client's socket, this is not currently handled by the `Client::dataRecv()` method and instead the server appears then to hang, expecting more data from the client.

This pull request allows this edge case to be handled correctly.